### PR TITLE
Add XML doccomments to classes and methods

### DIFF
--- a/Library/BMesh.cs
+++ b/Library/BMesh.cs
@@ -92,29 +92,56 @@ namespace BMeshLib
         ///////////////////////////////////////////////////////////////////////////
         #region [Topology Methods]
 
-        /**
-         * Add a new vertex to the mesh.
-         */
+        /// <summary>
+        /// Adds the specified <see cref="Vertex"/> to the <see cref="BMesh"/>.
+        /// </summary>
+        /// <param name="vert">The <see cref="Vertex"/> to add to the <see cref="BMesh"/>.</param>
+        /// <returns>The <see cref="Vertex"/> that was added.</returns>
         public Vertex AddVertex(Vertex vert)
         {
             EnsureVertexAttributes(vert);
             vertices.Add(vert);
             return vert;
         }
+        
+        /// <summary>
+        /// Adds a new <see cref="Vertex"/> to the <see cref="BMesh"/> with the specified position.
+        /// </summary>
+        /// <param name="point">The position of the <see cref="Vertex"/> to
+        /// create and add to the <see cref="BMeshLib"/>.</param>
+        /// <returns>The <see cref="Vertex"/> that was created and added.</returns>
         public Vertex AddVertex(Vector3 point)
         {
             return AddVertex(new Vertex(point));
         }
+        
+        /// <summary>
+        /// Adds a new <see cref="Vertex"/> to the <see cref="BMesh"/> with the specified position.
+        /// </summary>
+        /// <param name="x">The x position of the <see cref="Vertex"/> to create.</param>
+        /// <param name="y">The y position of the <see cref="Vertex"/> to create.</param>
+        /// <param name="z">The z position of the <see cref="Vertex"/> to create.</param>
+        /// <returns>The <see cref="Vertex"/> that was created and added.</returns>
         public Vertex AddVertex(float x, float y, float z)
         {
             return AddVertex(new Vector3(x, y, z));
         }
-
-        /**
-         * Add a new edge between two vertices. If there is already such edge,
-         * return it without adding a new one.
-         * If the vertices are not part of the mesh, the behavior is undefined.
-         */
+        
+        /// <summary>
+        /// Adds a new <see cref="Edge"/> comprised of the specified vertices.
+        /// If there is already an <see cref="Edge"/> between them, return it
+        /// without creating a new one.
+        /// </summary>
+        /// <remarks>
+        /// If the vertices are not part of the <see cref="BMeshLib"/>,
+        /// the behavior is undefined.
+        /// </remarks>
+        /// <param name="vert1">The <see cref="Vertex"/> used for one end of the <see cref="Edge"/>.</param>
+        /// <param name="vert2">The <see cref="Vertex"/> used for one end of the <see cref="Edge"/>.</param>
+        /// <returns>
+        /// An <see cref="Edge"/> in the <see cref="BMesh"/> that is comprised of <paramref name="vert1"/>
+        /// and <paramref name="vert2"/>.
+        /// </returns>
         public Edge AddEdge(Vertex vert1, Vertex vert2)
         {
             Debug.Assert(vert1 != vert2);
@@ -161,17 +188,35 @@ namespace BMeshLib
             return edge;
         }
 
+        /// <summary>
+        /// Adds a new <see cref="Edge"/> comprised of the vertices at the specified indices.
+        /// If there is already an <see cref="Edge"/> between them, return it
+        /// without creating a new one.
+        /// </summary>
+        /// <remarks>
+        /// If the vertices are not part of the <see cref="BMeshLib"/>,
+        /// the behavior is undefined.
+        /// </remarks>
+        /// <param name="v1">The index of the <see cref="Vertex"/> to use for one end of the <see cref="Edge"/>.</param>
+        /// <param name="v2">The index of the <see cref="Vertex"/> to use for one end of the <see cref="Edge"/>.</param>
+        /// <returns>
+        /// An <see cref="Edge"/> in the <see cref="BMesh"/> that is comprised of the
+        /// <see cref="Vertex"/> at index <paramref name="v1"/> and the <see cref="Vertex"/>
+        /// at index <paramref name="v2"/>.
+        /// </returns>
         public Edge AddEdge(int v1, int v2)
         {
             return AddEdge(vertices[v1], vertices[v2]);
         }
-
-        /**
-         * Add a new face that connects the array of vertices provided.
-         * The vertices must be part of the mesh, otherwise the behavior is
-         * undefined.
-         * NB: There is no AddLoop, because a loop is an element of a face
-         */
+        
+        /// <summary>
+        /// Adds a new <see cref="Face"/> with loops that is comprised of the specified <see cref="Vertex"/>s.
+        /// </summary>
+        /// <param name="fVerts">The vertices that are used to create the <see cref="Face"/>.</param>
+        /// <returns>The <see cref="Face"/> created using the specified vertices.</returns>
+        /// <remarks>
+        /// The vertices must be part of the mesh, otherwise the behavior is undefined.
+        /// </remarks>
         public Face AddFace(Vertex[] fVerts)
         {
             if (fVerts.Length == 0) return null;
@@ -201,41 +246,110 @@ namespace BMeshLib
             return f;
         }
 
+        /// <summary>
+        /// Adds a new <see cref="Face"/> with loops that is comprised of the specified <see cref="Vertex"/>s.
+        /// </summary>
+        /// <param name="v0">One of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="v1">One of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <returns>The <see cref="Face"/> created using the specified vertices.</returns>
+        /// <remarks>
+        /// The vertices must be part of the mesh, otherwise the behavior is undefined.
+        /// </remarks>
         public Face AddFace(Vertex v0, Vertex v1)
         {
             return AddFace(new Vertex[] { v0, v1 });
         }
 
+        /// <summary>
+        /// Adds a new <see cref="Face"/> with loops that is comprised of the specified <see cref="Vertex"/>s.
+        /// </summary>
+        /// <param name="v0">One of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="v1">One of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="v2">One of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <returns>The <see cref="Face"/> created using the specified vertices.</returns>
+        /// <remarks>
+        /// The vertices must be part of the mesh, otherwise the behavior is undefined.
+        /// </remarks>
         public Face AddFace(Vertex v0, Vertex v1, Vertex v2)
         {
             return AddFace(new Vertex[] { v0, v1, v2 });
         }
 
+        /// <summary>
+        /// Adds a new <see cref="Face"/> with loops that is comprised of the specified <see cref="Vertex"/>s.
+        /// </summary>
+        /// <param name="v0">One of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="v1">One of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="v2">One of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="v3">One of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <returns>The <see cref="Face"/> created using the specified vertices.</returns>
+        /// <remarks>
+        /// The vertices must be part of the mesh, otherwise the behavior is undefined.
+        /// </remarks>
         public Face AddFace(Vertex v0, Vertex v1, Vertex v2, Vertex v3)
         {
             return AddFace(new Vertex[] { v0, v1, v2, v3 });
         }
 
+        /// <summary>
+        /// Adds a new <see cref="Face"/> with loops that is comprised of the specified <see cref="Vertex"/>s.
+        /// </summary>
+        /// <param name="i0">The index of one of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="i1">The index of one of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <returns>The <see cref="Face"/> created using the specified vertices.</returns>
+        /// <remarks>
+        /// The vertices must be part of the mesh, otherwise the behavior is undefined.
+        /// </remarks>
         public Face AddFace(int i0, int i1)
         {
             return AddFace(new Vertex[] { vertices[i0], vertices[i1] });
         }
 
+        /// <summary>
+        /// Adds a new <see cref="Face"/> with loops that is comprised of the specified <see cref="Vertex"/>s.
+        /// </summary>
+        /// <param name="i0">The index of one of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="i1">The index of one of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="i2">The index of one of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <returns>The <see cref="Face"/> created using the specified vertices.</returns>
+        /// <remarks>
+        /// The vertices must be part of the mesh, otherwise the behavior is undefined.
+        /// </remarks>
         public Face AddFace(int i0, int i1, int i2)
         {
             return AddFace(new Vertex[] { vertices[i0], vertices[i1], vertices[i2] });
         }
 
+        /// <summary>
+        /// Adds a new <see cref="Face"/> with loops that is comprised of the specified <see cref="Vertex"/>s.
+        /// </summary>
+        /// <param name="i0">The index of one of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="i1">The index of one of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="i2">The index of one of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <param name="i3">The index of one of the <see cref="Vertex"/>s to use to create the <see cref="Face"/>.</param>
+        /// <returns>The <see cref="Face"/> created using the specified vertices.</returns>
+        /// <remarks>
+        /// The vertices must be part of the mesh, otherwise the behavior is undefined.
+        /// </remarks>
         public Face AddFace(int i0, int i1, int i2, int i3)
         {
             return AddFace(new Vertex[] { vertices[i0], vertices[i1], vertices[i2], vertices[i3] });
         }
-
-        /**
-         * Return an edge that links vert1 to vert2 in the mesh (an arbitrary one
-         * if there are several such edges, which is possible with this structure).
-         * Return null if there is no edge between vert1 and vert2 in the mesh.
-         */
+        
+        /// <summary>
+        /// Searches for an <see cref="Edge"/> that consists of the specified
+        /// <see cref="Vertex"/>s and returns the first occurence.
+        /// </summary>
+        /// <param name="vert1">
+        /// One of the <see cref="Vertex"/>s that consist the <see cref="Edge"/> to search for.
+        /// </param>
+        /// <param name="vert2">
+        /// One of the <see cref="Vertex"/>s that consist the <see cref="Edge"/> to search for.
+        /// </param>
+        /// <returns>
+        /// The first <see cref="Edge"/> that consists of <paramref name="vert1"/>
+        /// and <paramref name="vert2"/>, if found; otherwise <c>null</c>.
+        /// </returns>
         public Edge FindEdge(Vertex vert1, Vertex vert2)
         {
             Debug.Assert(vert1 != vert2);
@@ -252,12 +366,16 @@ namespace BMeshLib
             } while (e1 != vert1.edge && e2 != vert2.edge);
             return null;
         }
-
-        /**
-         * Remove the provided vertex from the mesh.
-         * Removing a vertex also removes all the edges/loops/faces that use it.
-         * If the vertex was not part of this mesh, the behavior is undefined.
-         */
+        
+        /// <summary>
+        /// Removes the specified <see cref="Vertex"/> from the <see cref="BMesh"/>,
+        /// also removes all <see cref="Edge"/>s, <see cref="Loop"/>s
+        /// and <see cref="Face"/>s that use it.
+        /// </summary>
+        /// <param name="v">The <see cref="Vertex"/> to remove from the <see cref="BMesh"/>.</param>
+        /// <remarks>
+        /// If the specified <see cref="Vertex"/> is not part of the <see cref="BMesh"/>, the behavior is undefined.
+        /// </remarks>
         public void RemoveVertex(Vertex v)
         {
             while (v.edge != null)
@@ -268,11 +386,14 @@ namespace BMeshLib
             vertices.Remove(v);
         }
 
-        /**
-         * Remove the provided edge from the mesh.
-         * Removing an edge also removes all associated loops/faces.
-         * If the edge was not part of this mesh, the behavior is undefined.
-         */
+        /// <summary>
+        /// Removes the specified <see cref="Edge"/> from the <see cref="BMesh"/>,
+        /// also removes all <see cref="Loop"/>s and <see cref="Face"/>s that use it.
+        /// </summary>
+        /// <param name="e">The <see cref="Edge"/> to remove from the <see cref="BMesh"/>.</param>
+        /// <remarks>
+        /// If the specified <see cref="Edge"/> is not part of the <see cref="BMesh"/>, the behavior is undefined.
+        /// </remarks>
         public void RemoveEdge(Edge e)
         {
             while (e.loop != null)
@@ -329,11 +450,14 @@ namespace BMeshLib
             loops.Remove(l);
         }
 
-        /**
-         * Remove the provided face from the mesh.
-         * If the face was not part of this mesh, the behavior is undefined.
-         * (actually almost ensured to be a true mess, but do as it pleases you :D)
-         */
+        /// <summary>
+        /// Removes the specified <see cref="Face"/> from the <see cref="BMesh"/>,
+        /// also removes all associated <see cref="Loop"/>s.
+        /// </summary>
+        /// <param name="f">The <see cref="Face"/> to remove from the <see cref="BMesh"/>.</param>
+        /// <remarks>
+        /// If the specified <see cref="Face"/> is not part of the <see cref="BMesh"/>, the behavior is undefined.
+        /// </remarks>
         public void RemoveFace(Face f)
         {
             Loop l = f.loop;
@@ -348,8 +472,7 @@ namespace BMeshLib
             faces.Remove(f);
         }
         #endregion
-
-
+        
         ///////////////////////////////////////////////////////////////////////////
         #region [Vertex Attribute Methods]
 

--- a/Library/Edge.cs
+++ b/Library/Edge.cs
@@ -40,7 +40,7 @@ namespace BMeshLib
         public Loop loop; // first node of the list of faces that use this edge. Navigate list using radial_next
 
         /// <summary>
-        /// Whether the specified <see cref="Vertex"/> is one of the vertices that make up the <see cref="Edge"/>.
+        /// Whether the specified <see cref="Vertex"/> is one of the vertices that comprise the <see cref="Edge"/>.
         /// </summary>
         /// <param name="v">The <see cref="Vertex"/> to compare.</param>
         /// <returns><c>true</c> if <paramref name="v"/> is used by the <see cref="Edge"/>; otherwise, <c>false</c>.</returns>
@@ -50,11 +50,14 @@ namespace BMeshLib
         }
 
         /// <summary>
-        /// Returns the other <see cref="Vertex"/> that makes up the <see cref="Edge"/> of the specified <see cref="Vertex"/>.
+        /// Returns the other <see cref="Vertex"/> that comprises the <see cref="Edge"/>.
         /// </summary>
-        /// <remarks>Assumes that the specified <see cref="Vertex"/> is one of the vertices that make up the <see cref="Edge"/>; otherwise, behavior is undefined.</remarks>
+        /// <remarks>
+        /// Assumes that the specified <see cref="Vertex"/> is one of the two vertices 
+        /// that comprise the <see cref="Edge"/>; otherwise, behavior is undefined.
+        /// </remarks>
         /// <param name="v">The <see cref="Vertex"/> to get the other of.</param>
-        /// <returns>The other <see cref="Vertex"/> that makes up the edge. Shorthand for <c><paramref name="v"/> == <see cref="vert1"/> ? <see cref="vert2"/> : <see cref="vert1"/></c>.</returns>
+        /// <returns>The other <see cref="Vertex"/> that makes up the edge.</returns>
         public Vertex OtherVertex(Vertex v)
         {
             Debug.Assert(ContainsVertex(v));
@@ -62,11 +65,30 @@ namespace BMeshLib
         }
 
         /// <summary>
-        /// Returns the next <see cref="Edge"/> in the linked list of edges that use the specified <see cref="Vertex"/>.
+        /// Returns the next <see cref="Edge"/> in the linked list of edges that use the specified <see cref="Vertex"/>. (Opposite of <see cref="Prev(Vertex)"/>).
         /// </summary>
-        /// <remarks>Assumes that the specified <see cref="Vertex"/> is one of the vertices that make up the <see cref="Edge"/>; otherwise, behavior is undefined.</remarks>
-        /// <param name="v"></param>
-        /// <returns>The next <see cref="Edge"/> in the linked list of edges that use <paramref name="v"/>. Shorthand for <c><paramref name="v"/> == <see cref="vert1"/> ? <see cref="next1"/> : <see cref="next2"/></c>.</returns>
+        /// <remarks>
+        /// Assumes that the specified <see cref="Vertex"/> is one of the vertices that 
+        /// comprise the <see cref="Edge"/>; otherwise, behavior is undefined.
+        /// It is ensured calling <c>Next</c> on each resulting <see cref="Edge"/> will iterate through
+        /// all edges that the specified <see cref="Vertex"/> comprises.
+        /// </remarks>
+        /// <example>
+        /// For instance the following iterates through all edges:
+        /// <code>
+        /// Edge firstEdge = edge;
+        /// do {
+        ///     // do something with `edge`
+        ///     edge = edge.Next(v);
+        /// } while(edge != firstEdge);
+        /// </code>
+        /// </example>
+        /// <seealso cref="Vertex.NeighborEdges"/>
+        /// <param name="v">The <see cref="Vertex"/> to get the next <see cref="Edge"/> of.</param>
+        /// <returns>
+        /// The next <see cref="Edge"/> in the linked list of edges that uses <paramref name="v"/>, 
+        /// bothing edges having <paramref name="v"/> in common.
+        /// </returns>
         public Edge Next(Vertex v)
         {
             Debug.Assert(ContainsVertex(v));
@@ -84,11 +106,30 @@ namespace BMeshLib
         }
 
         /// <summary>
-        /// Returns the previous <see cref="Edge"/> in the linked list of edges that use the specified <see cref="Vertex"/>.
+        /// Returns the previous <see cref="Edge"/> in the linked list of edges that use the specified <see cref="Vertex"/>. (Opposite of <see cref="Next(Vertex)"/>).
         /// </summary>
-        /// <remarks>Assumes that the specified <see cref="Vertex"/> is one of the vertices that make up the <see cref="Edge"/>; otherwise, behavior is undefined.</remarks>
-        /// <param name="v"></param>
-        /// <returns>The previous <see cref="Edge"/> in the linked list of edges that use <paramref name="v"/>. Shorthand for <c><paramref name="v"/> == <see cref="vert1"/> ? <see cref="prev1"/> : <see cref="prev2"/></c>.</returns>
+        /// <remarks>
+        /// Assumes that the specified <see cref="Vertex"/> is one of the vertices that 
+        /// comprise the <see cref="Edge"/>; otherwise, behavior is undefined.
+        /// It is ensured calling <c>Prev</c> on each resulting <see cref="Edge"/> will iterate through
+        /// all edges that the specified <see cref="Vertex"/> comprises.
+        /// </remarks>
+        /// <example>
+        /// For instance the following iterates through all edges:
+        /// <code>
+        /// Edge firstEdge = edge;
+        /// do {
+        ///     // do something with `edge`
+        ///     edge = edge.Prev(v);
+        /// } while(edge != firstEdge);
+        /// </code>
+        /// </example>
+        /// <seealso cref="Vertex.NeighborEdges"/>
+        /// <param name="v">The <see cref="Vertex"/> to get the previous <see cref="Edge"/> of.</param>
+        /// <returns>
+        /// The previous <see cref="Edge"/> in the linked list of edges that uses <paramref name="v"/>, 
+        /// bothing edges having <paramref name="v"/> in common.
+        /// </returns>
         public Edge Prev(Vertex v)
         {
             Debug.Assert(ContainsVertex(v));
@@ -108,7 +149,7 @@ namespace BMeshLib
         /// <summary>
         /// Returns all <see cref="Face"/>s that use the <see cref="Edge"/> as a side.
         /// </summary>
-        /// <returns>all <see cref="Face"/>s that use the <see cref="Edge"/> as one of it's sides.</returns>
+        /// <returns>All <see cref="Face"/>s that use the <see cref="Edge"/> as one of it's sides.</returns>
         public List<Face> NeighborFaces()
         {
             var faces = new List<Face>();

--- a/Library/Edge.cs
+++ b/Library/Edge.cs
@@ -43,7 +43,9 @@ namespace BMeshLib
         /// Whether the specified <see cref="Vertex"/> is one of the vertices that comprise the <see cref="Edge"/>.
         /// </summary>
         /// <param name="v">The <see cref="Vertex"/> to compare.</param>
-        /// <returns><c>true</c> if <paramref name="v"/> is used by the <see cref="Edge"/>; otherwise, <c>false</c>.</returns>
+        /// <returns>
+        /// <c>true</c> if <paramref name="v"/> is used by the <see cref="Edge"/>; otherwise, <c>false</c>.
+        /// </returns>
         public bool ContainsVertex(Vertex v)
         {
             return v == vert1 || v == vert2;
@@ -65,7 +67,8 @@ namespace BMeshLib
         }
 
         /// <summary>
-        /// Returns the next <see cref="Edge"/> in the linked list of edges that use the specified <see cref="Vertex"/>. (Opposite of <see cref="Prev(Vertex)"/>).
+        /// Returns the next <see cref="Edge"/> in the linked list of edges that use
+        /// the specified <see cref="Vertex"/>. (Opposite of <see cref="Prev(Vertex)"/>).
         /// </summary>
         /// <remarks>
         /// Assumes that the specified <see cref="Vertex"/> is one of the vertices that 
@@ -106,7 +109,8 @@ namespace BMeshLib
         }
 
         /// <summary>
-        /// Returns the previous <see cref="Edge"/> in the linked list of edges that use the specified <see cref="Vertex"/>. (Opposite of <see cref="Next(Vertex)"/>).
+        /// Returns the previous <see cref="Edge"/> in the linked list of edges that
+        /// use the specified <see cref="Vertex"/>. (Opposite of <see cref="Next(Vertex)"/>).
         /// </summary>
         /// <remarks>
         /// Assumes that the specified <see cref="Vertex"/> is one of the vertices that 

--- a/Library/Edge.cs
+++ b/Library/Edge.cs
@@ -23,6 +23,10 @@ namespace BMeshLib
      * next one, so the function Next() is provided to return either next1 or
      * next2 depending on the vertex of interest.
      */
+    /// <summary>
+    /// Links two <see cref="Vertex"/>s together, and may or may not be part of a <see cref="Face"/>.
+    /// </summary>
+    /// <remarks>Multiple <see cref="Face"/>s can share the same <see cref="Edge"/>.</remarks>
     public class Edge
     {
         public int id; // [attribute]
@@ -35,28 +39,34 @@ namespace BMeshLib
         public Edge prev2;
         public Loop loop; // first node of the list of faces that use this edge. Navigate list using radial_next
 
-        /**
-         * Tells whether a vertex is one of the extremities of this edge.
-         */
+        /// <summary>
+        /// Whether the specified <see cref="Vertex"/> is one of the vertices that make up the <see cref="Edge"/>.
+        /// </summary>
+        /// <param name="v">The <see cref="Vertex"/> to compare.</param>
+        /// <returns><c>true</c> if <paramref name="v"/> is used by the <see cref="Edge"/>; otherwise, <c>false</c>.</returns>
         public bool ContainsVertex(Vertex v)
         {
             return v == vert1 || v == vert2;
         }
 
-        /**
-         * If one gives a vertex of the edge to this function, it returns the
-         * other vertex of the edge. Otherwise, the behavior is undefined.
-         */
+        /// <summary>
+        /// Returns the other <see cref="Vertex"/> that makes up the <see cref="Edge"/> of the specified <see cref="Vertex"/>.
+        /// </summary>
+        /// <remarks>Assumes that the specified <see cref="Vertex"/> is one of the vertices that make up the <see cref="Edge"/>; otherwise, behavior is undefined.</remarks>
+        /// <param name="v">The <see cref="Vertex"/> to get the other of.</param>
+        /// <returns>The other <see cref="Vertex"/> that makes up the edge. Shorthand for <c><paramref name="v"/> == <see cref="vert1"/> ? <see cref="vert2"/> : <see cref="vert1"/></c>.</returns>
         public Vertex OtherVertex(Vertex v)
         {
             Debug.Assert(ContainsVertex(v));
             return v == vert1 ? vert2 : vert1;
         }
 
-        /**
-         * If one gives a vertex of the edge to this function, it returns the
-         * next edge in the linked list of edges that use this vertex.
-         */
+        /// <summary>
+        /// Returns the next <see cref="Edge"/> in the linked list of edges that use the specified <see cref="Vertex"/>.
+        /// </summary>
+        /// <remarks>Assumes that the specified <see cref="Vertex"/> is one of the vertices that make up the <see cref="Edge"/>; otherwise, behavior is undefined.</remarks>
+        /// <param name="v"></param>
+        /// <returns>The next <see cref="Edge"/> in the linked list of edges that use <paramref name="v"/>. Shorthand for <c><paramref name="v"/> == <see cref="vert1"/> ? <see cref="next1"/> : <see cref="next2"/></c>.</returns>
         public Edge Next(Vertex v)
         {
             Debug.Assert(ContainsVertex(v));
@@ -73,9 +83,12 @@ namespace BMeshLib
             else next2 = other;
         }
 
-        /**
-         * Similar to Next() but to go backward in the double-linked list
-         */
+        /// <summary>
+        /// Returns the previous <see cref="Edge"/> in the linked list of edges that use the specified <see cref="Vertex"/>.
+        /// </summary>
+        /// <remarks>Assumes that the specified <see cref="Vertex"/> is one of the vertices that make up the <see cref="Edge"/>; otherwise, behavior is undefined.</remarks>
+        /// <param name="v"></param>
+        /// <returns>The previous <see cref="Edge"/> in the linked list of edges that use <paramref name="v"/>. Shorthand for <c><paramref name="v"/> == <see cref="vert1"/> ? <see cref="prev1"/> : <see cref="prev2"/></c>.</returns>
         public Edge Prev(Vertex v)
         {
             Debug.Assert(ContainsVertex(v));
@@ -92,9 +105,10 @@ namespace BMeshLib
             else prev2 = other;
         }
 
-        /**
-         * Return all faces that use this edge as a side.
-         */
+        /// <summary>
+        /// Returns all <see cref="Face"/>s that use the <see cref="Edge"/> as a side.
+        /// </summary>
+        /// <returns>all <see cref="Face"/>s that use the <see cref="Edge"/> as one of it's sides.</returns>
         public List<Face> NeighborFaces()
         {
             var faces = new List<Face>();
@@ -110,9 +124,10 @@ namespace BMeshLib
             return faces;
         }
 
-        /**
-         * Compute the barycenter of the edge's vertices
-         */
+        /// <summary>
+        /// The center of the <see cref="Edge"/>'s vertices.
+        /// </summary>
+        /// <returns>The center between <see cref="vert1"/> and <see cref="vert2"/>.</returns>
         public Vector3 Center()
         {
             return (vert1.point + vert2.point) * 0.5f;

--- a/Library/Edge.cs
+++ b/Library/Edge.cs
@@ -3,27 +3,27 @@ using UnityEngine;
 
 namespace BMeshLib
 {
-    /**
-     * An edge links to vertices together, and may or may not be part of a face.
-     * An edge can be shared by several faces.
-     * 
-     * Technical Note: The structure stores a reference to the two vertices.
-     * Although the role of these two vertices is perfectly symmetrical, this
-     * makes the iterations over linked list slightly trickier than expected.
-     * 
-     * The edge is a node of two (double) linked lists at the same time. Let's
-     * recall that a (simply) linked list of Stuff is made of nodes of the form
-     *     Node {
-     *         Stuff value;
-     *         Node next;
-     *     }
-     * Here we provide two "next", depending on whether the vertex that we are
-     * interested in is vertex1 or vertex2. Note that a vertex stored in the
-     * "vertex1" field for one edge might be stored in the "vertex2" of the
-     * next one, so the function Next() is provided to return either next1 or
-     * next2 depending on the vertex of interest.
-     */
-    /// <summary>
+    
+     // An edge links to vertices together, and may or may not be part of a face.
+     // An edge can be shared by several faces.
+     //
+     // Technical Note: The structure stores a reference to the two vertices.
+     // Although the role of these two vertices is perfectly symmetrical, this
+     // makes the iterations over linked list slightly trickier than expected.
+     //
+     // The edge is a node of two (double) linked lists at the same time. Let's
+     // recall that a (simply) linked list of Stuff is made of nodes of the form
+     //     Node {
+     //         Stuff value;
+     //         Node next;
+     //     }
+     // Here we provide two "next", depending on whether the vertex that we are
+     // interested in is vertex1 or vertex2. Note that a vertex stored in the
+     // "vertex1" field for one edge might be stored in the "vertex2" of the
+     // next one, so the function Next() is provided to return either next1 or
+     // next2 depending on the vertex of interest.
+
+     /// <summary>
     /// Links two <see cref="Vertex"/>s together, and may or may not be part of a <see cref="Face"/>.
     /// </summary>
     /// <remarks>Multiple <see cref="Face"/>s can share the same <see cref="Edge"/>.</remarks>
@@ -87,7 +87,7 @@ namespace BMeshLib
         /// <param name="v">The <see cref="Vertex"/> to get the next <see cref="Edge"/> of.</param>
         /// <returns>
         /// The next <see cref="Edge"/> in the linked list of edges that uses <paramref name="v"/>, 
-        /// bothing edges having <paramref name="v"/> in common.
+        /// both edges having <paramref name="v"/> in common.
         /// </returns>
         public Edge Next(Vertex v)
         {

--- a/Library/Face.cs
+++ b/Library/Face.cs
@@ -22,7 +22,9 @@ namespace BMeshLib
         /// <summary>
         /// Returns the ordered <see cref="Vertex"/>s that comprise the corners of the <see cref="Face"/>.
         /// </summary>
-        /// <returns>The vertices that comprise corners of the <see cref="Face"/>.</returns>
+        /// <returns>
+        /// The vertices that comprise corners of the <see cref="Face"/>.
+        /// </returns>
         public List<Vertex> NeighborVertices()
         {
             var verts = new List<Vertex>();
@@ -39,11 +41,14 @@ namespace BMeshLib
         }
 
         /// <summary>
-        /// Returns the <see cref="BMeshLib.Loop"/> in the <see cref="Face"/> whose <see cref="Loop.vert"/> matches the specified <see cref="Vertex"/>.
+        /// Returns the <see cref="BMeshLib.Loop"/> in the <see cref="Face"/>
+        /// whose <see cref="Loop.vert"/> matches the specified <see cref="Vertex"/>.
         /// </summary>
         /// <param name="v">The <see cref="Vertex"/> to get the <see cref="BMeshLib.Loop"/> of.</param>
         /// <returns>
-        /// The <see cref="BMeshLib.Loop"/> of the <see cref="Face"/> whose <see cref="Loop.vert"/> matches <paramref name="v"/> if it is part of the <see cref="Face"/>; otherwise, <c>null</c>.
+        /// The <see cref="BMeshLib.Loop"/> of the <see cref="Face"/>
+        /// whose <see cref="Loop.vert"/> matches <paramref name="v"/>
+        /// if it is part of the <see cref="Face"/>; otherwise, <c>null</c>.
         /// </returns>
         public Loop Loop(Vertex v)
         {
@@ -63,8 +68,11 @@ namespace BMeshLib
         /// <summary>
         /// Returns the ordered <see cref="Edge"/>s around the <see cref="Face"/>.
         /// </summary>
-        /// <remarks>Garrantied to match the order of <see cref="NeighborVertices"/>. So that <c>edge[0] = vert[0]-->vert[1], edge[1] = vert[1]-->vert[2], etc.</c></remarks>
         /// <returns>The <see cref="Edge"/>s that make up the <see cref="Face"/>.</returns>
+        /// /// <remarks>
+        /// Guarantied to match the order of <see cref="NeighborVertices"/>.
+        /// So that <c>edge[0] = vert[0]-->vert[1], edge[1] = vert[1]-->vert[2], etc.</c>
+        /// </remarks>
         public List<Edge> NeighborEdges()
         {
             var edges = new List<Edge>();

--- a/Library/Face.cs
+++ b/Library/Face.cs
@@ -9,6 +9,9 @@ namespace BMeshLib
      * makes sense only 1. for clarity, because loops are a less intuitive
      * object and 2. to store face attributes.
      */
+    /// <summary>
+    /// Represents a face of a mesh in a <see cref="BMesh"/>.
+    /// </summary>
     public class Face
     {
         public int id; // [attribute]
@@ -16,9 +19,10 @@ namespace BMeshLib
         public int vertcount; // stored for commodity, can be recomputed easily
         public Loop loop; // navigate list using next
 
-        /**
-         * Get the list of vertices used by the face, ordered.
-         */
+        /// <summary>
+        /// Returns the ordered <see cref="Vertex"/>s that are used by the <see cref="Face"/>.
+        /// </summary>
+        /// <returns>The vertices that make up the corner's of the <see cref="Face"/>.</returns>
         public List<Vertex> NeighborVertices()
         {
             var verts = new List<Vertex>();
@@ -34,10 +38,13 @@ namespace BMeshLib
             return verts;
         }
 
-        /**
-         * Assuming the vertex is part of the face, return the loop such that
-         * loop.vert = v. Return null otherwise.
-         */
+        /// <summary>
+        /// Returns the <see cref="BMeshLib.Loop"/> in the <see cref="Face"/> whose <see cref="Loop.vert"/> matches the specified <see cref="Vertex"/>.
+        /// </summary>
+        /// <param name="v">The <see cref="Vertex"/> to get the <see cref="BMeshLib.Loop"/> of.</param>
+        /// <returns>
+        /// The <see cref="BMeshLib.Loop"/> of the <see cref="Face"/> whose <see cref="Loop.vert"/> matches <paramref name="v"/> if it is part of the <see cref="Face"/>; otherwise, <c>null</c>.
+        /// </returns>
         public Loop Loop(Vertex v)
         {
             if (this.loop != null)
@@ -53,11 +60,11 @@ namespace BMeshLib
             return null;
         }
 
-        /**
-         * Get the list of edges around the face.
-         * It is garrantied to match the order of NeighborVertices(), so that
-         * edge[0] = vert[0]-->vert[1], edge[1] = vert[1]-->vert[2], etc.
-         */
+        /// <summary>
+        /// Returns the ordered <see cref="Edge"/>s around the <see cref="Face"/>.
+        /// </summary>
+        /// <remarks>Garrantied to match the order of <see cref="NeighborVertices"/>. So that <c>edge[0] = vert[0]-->vert[1], edge[1] = vert[1]-->vert[2], etc.</c></remarks>
+        /// <returns>The <see cref="Edge"/>s that make up the <see cref="Face"/>.</returns>
         public List<Edge> NeighborEdges()
         {
             var edges = new List<Edge>();
@@ -73,9 +80,10 @@ namespace BMeshLib
             return edges;
         }
 
-        /**
-         * Compute the barycenter of the face vertices
-         */
+        /// <summary>
+        /// The center of the vertices that are used by the <see cref="Face"/>.
+        /// </summary>
+        /// <returns>The center of <see cref="Face"/>.</returns>
         public Vector3 Center()
         {
             Vector3 p = Vector3.zero;

--- a/Library/Face.cs
+++ b/Library/Face.cs
@@ -4,14 +4,14 @@ using UnityEngine;
 
 namespace BMeshLib
 {
-    /**
-     * A face is almost nothing more than a loop. Having a different structure
-     * makes sense only 1. for clarity, because loops are a less intuitive
-     * object and 2. to store face attributes.
-     */
     /// <summary>
     /// Represents a face of a mesh in a <see cref="BMesh"/>.
     /// </summary>
+    /// <remarks>
+    /// A <see cref="Face"/> is little more than a <see cref="BMeshLib.Loop"/>.
+    /// However it is used since it is more intuitive than a <see cref="BMeshLib.Loop"/>,
+    /// and stores face <see cref="AttributeValue"/>s.
+    /// </remarks>
     public class Face
     {
         public int id; // [attribute]

--- a/Library/Face.cs
+++ b/Library/Face.cs
@@ -20,9 +20,9 @@ namespace BMeshLib
         public Loop loop; // navigate list using next
 
         /// <summary>
-        /// Returns the ordered <see cref="Vertex"/>s that are used by the <see cref="Face"/>.
+        /// Returns the ordered <see cref="Vertex"/>s that comprise the corners of the <see cref="Face"/>.
         /// </summary>
-        /// <returns>The vertices that make up the corner's of the <see cref="Face"/>.</returns>
+        /// <returns>The vertices that comprise corners of the <see cref="Face"/>.</returns>
         public List<Vertex> NeighborVertices()
         {
             var verts = new List<Vertex>();

--- a/Library/Loop.cs
+++ b/Library/Loop.cs
@@ -18,6 +18,9 @@ namespace BMeshLib
      * namely the radial list, that enables iterating over all the faces using
      * the same edge.
      */
+    /// <summary>
+    /// Represents a portion of a <see cref="Face"/>.
+    /// </summary>
     public class Loop
     {
         public Dictionary<string, AttributeValue> attributes; // [attribute] (extra attributes)
@@ -38,10 +41,10 @@ namespace BMeshLib
             SetFace(f);
         }
 
-        /**
-         * Insert the loop in the linked list of the face.
-         * (Used in constructor)
-         */
+        /// <summary>
+        /// Insert the <see cref="Loop"/> in to the linked list of the specified <see cref="Face"/>.
+        /// </summary>
+        /// <param name="f">The <see cref="Face"/> to insert the <see cref="Loop"/> in to.</param>
         public void SetFace(Face f)
         {
             Debug.Assert(this.face == null);
@@ -63,10 +66,10 @@ namespace BMeshLib
             this.face = f;
         }
 
-        /**
-         * Insert the loop in the radial linked list.
-         * (Used in constructor)
-         */
+        /// <summary>
+        /// Insert the <see cref="Loop"/> in to the radial linked list.
+        /// </summary>
+        /// <param name="e">The <see cref="Edge"/> to insert the <see cref="Loop"/> in to.</param>
         public void SetEdge(Edge e)
         {
             Debug.Assert(this.edge == null);

--- a/Library/Loop.cs
+++ b/Library/Loop.cs
@@ -3,25 +3,24 @@ using UnityEngine;
 
 namespace BMeshLib
 {
-    /**
-     * Since a face is basically a list of edges, and the Loop object is a node
-     * of this list, called so because the list must loop.
-     * A loop is associated to one and only one face.
-     * 
-     * A loop can be seen as a list of edges, it also stores a reference to a
-     * vertex for commodity but technically it could be found through the edge.
-     * It may also be interpreted as a "face corner", and is hence where one
-     * typically stores UVs, because one vertex may have different UV
-     * coordinates depending on the face.
-     * 
-     * On top of this, the loop is also used as a node of another linked list,
-     * namely the radial list, that enables iterating over all the faces using
-     * the same edge.
-     */
+    // Since a face is basically a list of edges, and the Loop object is a node
+    // of this list, called so because the list must loop.
+    // A loop is associated to one and only one face.
+    // 
+    // A loop can be seen as a list of edges, it also stores a reference to a
+    // vertex for commodity but technically it could be found through the edge.
+    // It may also be interpreted as a "face corner", and is hence where one
+    // typically stores UVs, because one vertex may have different UV
+    // coordinates depending on the face.
+    // 
+    // On top of this, the loop is also used as a node of another linked list,
+    // namely the radial list, that enables iterating over all the faces using
+    // the same edge.
+
     /// <summary>
     /// A combination of a <see cref="Vertex"/>, an <see cref="Edge"/> and a <see cref="Face"/>.
     /// Meant to provide fast access to neighboring edges, by traversing around the <see cref="Face"/> with <see cref="Edge.Next(Vertex)"/>
-    /// and <see cref="Edge.Prev(Vertex)"/>. Or by traversing around the <see cref="Vertex"/> with ReadialNext and RadialPrev.
+    /// and <see cref="Edge.Prev(Vertex)"/>. Or by traversing around the <see cref="Vertex"/> with RadialNext and RadialPrev.
     /// </summary>
     public class Loop
     {

--- a/Library/Loop.cs
+++ b/Library/Loop.cs
@@ -19,7 +19,9 @@ namespace BMeshLib
      * the same edge.
      */
     /// <summary>
-    /// Represents a portion of a <see cref="Face"/>.
+    /// A combination of a <see cref="Vertex"/>, an <see cref="Edge"/> and a <see cref="Face"/>.
+    /// Meant to provide fast access to neighboring edges, by traversing around the <see cref="Face"/> with <see cref="Edge.Next(Vertex)"/>
+    /// and <see cref="Edge.Prev(Vertex)"/>. Or by traversing around the <see cref="Vertex"/> with ReadialNext and RadialPrev.
     /// </summary>
     public class Loop
     {

--- a/Library/Vertex.cs
+++ b/Library/Vertex.cs
@@ -23,6 +23,12 @@ namespace BMeshLib
      * The vertex position does not affect topological algorithms, but is used by
      * commodity functions that help finding the center of an edge or a face.
      */
+    /// <summary>
+    /// Corresponds to a point in space, and is used by <see cref="Edge"/> and <see cref="Face"/> to construct a <see cref="BMesh"/>. 
+    /// </summary>
+    /// <remarks>
+    ///  Multiple <see cref="Edge"/>s and <see cref="Face"/>s can use the same <see cref="Vertex"/>, and multiple vertices can be located at the exact same position.
+    /// </remarks>
     public class Vertex
     {
         public int id; // [attribute]
@@ -35,9 +41,10 @@ namespace BMeshLib
             point = _point;
         }
 
-        /**
-         * List all edges reaching this vertex.
-         */
+        /// <summary>
+        /// Returns all <see cref="Edge"/>s that reach the <see cref="Vertex"/>.
+        /// </summary>
+        /// <returns>All <see cref="Edge"/>s that reach the <see cref="Vertex"/>. Uses <see cref="Edge.Next(Vertex)"/> from <see cref="edge"/> until it reaches <see cref="edge"/> again.</returns>
         public List<Edge> NeighborEdges()
         {
             var edges = new List<Edge>();
@@ -53,9 +60,10 @@ namespace BMeshLib
             return edges;
         }
 
-        /**
-         * Return all faces that use this vertex as a corner.
-         */
+        /// <summary>
+        /// Returns all <see cref="Face"/>s that use the <see cref="Vertex"/> as a corner.
+        /// </summary>
+        /// <returns>All <see cref="Face"/>s that use the <see cref="Vertex"/> as one of it's corners.</returns>
         public List<Face> NeighborFaces()
         {
             var faces = new HashSet<Face>();

--- a/Library/Vertex.cs
+++ b/Library/Vertex.cs
@@ -27,7 +27,8 @@ namespace BMeshLib
     /// Corresponds to a point in space, and is used by <see cref="Edge"/> and <see cref="Face"/> to construct a <see cref="BMesh"/>. 
     /// </summary>
     /// <remarks>
-    ///  Multiple <see cref="Edge"/>s and <see cref="Face"/>s can use the same <see cref="Vertex"/>, and multiple vertices can be located at the exact same position.
+    /// Multiple <see cref="Edge"/>s and <see cref="Face"/>s can use the same <see cref="Vertex"/>, 
+    /// and multiple vertices can be located at the exact same position.
     /// </remarks>
     public class Vertex
     {
@@ -44,7 +45,10 @@ namespace BMeshLib
         /// <summary>
         /// Returns all <see cref="Edge"/>s that reach the <see cref="Vertex"/>.
         /// </summary>
-        /// <returns>All <see cref="Edge"/>s that reach the <see cref="Vertex"/>. Uses <see cref="Edge.Next(Vertex)"/> from <see cref="edge"/> until it reaches <see cref="edge"/> again.</returns>
+        /// <returns>
+        /// All <see cref="Edge"/>s that reach the <see cref="Vertex"/>. 
+        /// Uses <see cref="Edge.Next(Vertex)"/> from <see cref="edge"/> until it reaches <see cref="edge"/> again.
+        /// </returns>
         public List<Edge> NeighborEdges()
         {
             var edges = new List<Edge>();

--- a/Library/Vertex.cs
+++ b/Library/Vertex.cs
@@ -49,8 +49,8 @@ namespace BMeshLib
         /// Returns all <see cref="Edge"/>s that reach the <see cref="Vertex"/>.
         /// </summary>
         /// <returns>
-        /// All <see cref="Edge"/>s that reach the <see cref="Vertex"/>. 
-        /// Uses <see cref="Edge.Next(Vertex)"/> from <see cref="edge"/> until it reaches <see cref="edge"/> again.
+        /// All <see cref="Edge"/>s that reach the <see cref="Vertex"/>. Uses
+        /// <see cref="Edge.Next(Vertex)"/> from <see cref="edge"/> until it reaches <see cref="edge"/> again.
         /// </returns>
         public List<Edge> NeighborEdges()
         {
@@ -70,7 +70,9 @@ namespace BMeshLib
         /// <summary>
         /// Returns all <see cref="Face"/>s that use the <see cref="Vertex"/> as a corner.
         /// </summary>
-        /// <returns>All <see cref="Face"/>s that use the <see cref="Vertex"/> as one of it's corners.</returns>
+        /// <returns>
+        /// All <see cref="Face"/>s that use the <see cref="Vertex"/> as one of it's corners.
+        /// </returns>
         public List<Face> NeighborFaces()
         {
             var faces = new HashSet<Face>();

--- a/Library/Vertex.cs
+++ b/Library/Vertex.cs
@@ -4,31 +4,34 @@ using UnityEngine;
 
 namespace BMeshLib
 {
-    /**
-     * NB: For all topology types, except for members marked as "attribute",
-     * all classes only store references to objects allocated by BMesh itself.
-     * Variables marked as attributes have no impact on the topological
-     * algorithm applied to the mesh (e.g. finding the neighbors), they are
-     * only set by calling code. In particuler, the 'id' field has no meaning
-     * for this class, it is put here purely for commodity, but don't expect it
-     * to get actually filled unless you explicitely did do.
-     */
+    //   NB: For all topology types, except for members marked as "attribute",
+    //   all classes only store references to objects allocated by BMesh itself.
+    //   Variables marked as attributes have no impact on the topological
+    //   algorithm applied to the mesh (e.g. finding the neighbors), they are
+    //   only set by calling code. In particuler, the 'id' field has no meaning
+    //   for this class, it is put here purely for commodity, but don't expect it
+    //   to get actually filled unless you explicitely did do.
+    //  
+    //  
+    //   A vertex corresponds roughly to a position in space. Many primitives
+    //   (edges, faces) can share a given vertex. Several vertices can be located
+    //   at the very same position.
+    //   It references a chained list of the edges that use it, embeded inside the Edge
+    //   structure (see below, and see implementation of NeighborEdges).
+    //   The vertex position does not affect topological algorithms, but is used by
+    //   commodity functions that help finding the center of an edge or a face.
 
-    /**
-     * A vertex corresponds roughly to a position in space. Many primitives
-     * (edges, faces) can share a given vertex. Several vertices can be located
-     * at the very same position.
-     * It references a chained list of the edges that use it, embeded inside the Edge
-     * structure (see below, and see implementation of NeighborEdges).
-     * The vertex position does not affect topological algorithms, but is used by
-     * commodity functions that help finding the center of an edge or a face.
-     */
     /// <summary>
-    /// Corresponds to a point in space, and is used by <see cref="Edge"/> and <see cref="Face"/> to construct a <see cref="BMesh"/>. 
+    /// Corresponds to a point in space, and is used by <see cref="Edge"/>
+    /// and <see cref="Face"/> to construct a <see cref="BMesh"/>. 
     /// </summary>
     /// <remarks>
-    /// Multiple <see cref="Edge"/>s and <see cref="Face"/>s can use the same <see cref="Vertex"/>, 
-    /// and multiple vertices can be located at the exact same position.
+    /// Multiple <see cref="Edge"/>s and <see cref="Face"/>s can use
+    /// a given <see cref="Vertex"/>, and multiple vertices can be located
+    /// at the exact same position. A <see cref="Vertex"/> references a chained list
+    /// of the <see cref="BMeshLib.Edge"/>s that use it embedded inside the edge structure.
+    /// The <see cref="Vertex"/>'s position does not affect topological algorithms,
+    /// but is used by commodity functions that help finding the center of an edge or a face.
     /// </remarks>
     public class Vertex
     {


### PR DESCRIPTION
Add doccomments to classes and methods that follow the styling of other C# doccomments.
This will need to be thoroughly reviewed to ensure that the accuracy of the comments.

### Current State
Only the  `Vertex, Edge, Loop, Face` class are commented so far.
All comments in the `Loop` class including the one on the class it self need to be rewritten for more clarity in what they do, however I am not 100% clear on what they are doing my self.
`Edge.SetNext` and `Edge.SetPrev` are not commented as I was not able to understand what they do in enough clarity to put in to a comment.
