### PR TITLE
Fix unintended instantiation of materials

### DIFF
--- a/Library/BMeshUnity.cs
+++ b/Library/BMeshUnity.cs
@@ -157,7 +157,7 @@ public class BMeshUnity
         var renderer = mf.GetComponent<MeshRenderer>();
         if (renderer)
         {
-            unityMesh.subMeshCount = Mathf.Max(unityMesh.subMeshCount, renderer.materials.Length);
+            unityMesh.subMeshCount = Mathf.Max(unityMesh.subMeshCount, renderer.sharedMaterials.Length);
         }
 
         for (int mat = 0; mat  < triangles.Length; ++mat)


### PR DESCRIPTION
The call to `.materials` causes all materials on the renderer to be duplicated, see:
https://docs.unity3d.com/ScriptReference/Renderer-materials.html