### PR TITLE
Added license meta file

### DIFF
--- a/LICENSE.meta
+++ b/LICENSE.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ac14c8e27d4c64bf388a05f222d9a778
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This fixes installing via the git URL, which throws an error at the moment like `has no meta file, but it's in an immutable folder. The asset will be ignored.`